### PR TITLE
Fix filenames

### DIFF
--- a/src/main/java/org/monarchinitiative/phenopacket2prompt/cmd/GbtTranslateBatchCommand.java
+++ b/src/main/java/org/monarchinitiative/phenopacket2prompt/cmd/GbtTranslateBatchCommand.java
@@ -83,8 +83,8 @@ public class GbtTranslateBatchCommand implements Callable<Integer> {
     }
 
 
-    private String getFileName(String phenopacketID) {
-        return phenopacketID.replaceAll("[^\\w]", phenopacketID).replaceAll("/","_") + "-prompt.txt";
+    private String getFileName(String phenopacketID, String languageCode) {
+        return phenopacketID.replaceAll("[^\\w]","_") + "_" + languageCode + "-prompt.txt";
     }
 
 
@@ -101,7 +101,7 @@ public class GbtTranslateBatchCommand implements Callable<Integer> {
                 continue;
             }
             PhenopacketDisease pdisease = diseaseList.get(0);
-            String promptFileName = getFileName( individual.getPhenopacketId());
+            String promptFileName = getFileName( individual.getPhenopacketId(), languageCode);
             String diagnosisLine = String.format("%s\t%s\t%s\t%s", pdisease.getDiseaseId(), pdisease.getLabel(), promptFileName, f.getAbsolutePath());
             try {
                 diagnosisList.add(diagnosisLine);
@@ -127,7 +127,7 @@ public class GbtTranslateBatchCommand implements Callable<Integer> {
                 continue;
             }
             PhenopacketDisease pdisease = diseaseList.get(0);
-            String promptFileName = getFileName( individual.getPhenopacketId());
+            String promptFileName = getFileName( individual.getPhenopacketId(), "en");
             String diagnosisLine = String.format("%s\t%s\t%s\t%s", pdisease.getDiseaseId(), pdisease.getLabel(), promptFileName, f.getAbsolutePath());
             try {
                 String prompt = generator.createPrompt(individual);


### PR DESCRIPTION
Fixed regex which created weird filenames. Also added a language code to the prompt file name. The proposed solution is to substitute all non-word characters to "_", but this should be done carefully, I don't think we want to produce file names too different from the phenopackets' original file name. Which makes me wonder, why do pheonpackets have ":" and "/" in their file names? See:

https://github.com/monarch-initiative/phenopacket2prompt/blob/df015bdaa4a5e1c9b0e11edcf7ba148a286c9ec6/src/main/java/org/monarchinitiative/phenopacket2prompt/cmd/GbtTranslateBatchCommand.java#L86-L88