### PR TITLE
Italian update

### DIFF
--- a/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/italian/PpktIndividualItalian.java
+++ b/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/italian/PpktIndividualItalian.java
@@ -11,116 +11,122 @@ import java.util.Optional;
 public class PpktIndividualItalian implements PPKtIndividualInfoGenerator {
 
 
-    private static final String FEMALE_FETUS = "un feto femmina";
-    private static final String MALE_FETUS = "un feto maschio";
-    private static final String FETUS = "un feto";
 
-    private static final String FEMALE_NEWBORN = "una neonata femmina";
-    private static final String MALE_NEWBORN = "un neonato maschio";
-    private static final String NEWBORN = "un neonato";
-
-    private static final String FEMALE_INFANT = "un'infante femmina";
-    private static final String MALE_INFANT = "un infante maschio";
-    private static final String INFANT = "un infante";
-
-    private static final String FEMALE_CHILD = "una bambina";
-    private static final String MALE_CHILD = "un bambino";
-    private static final String CHILD = "un bambino";
-
-    private static final String FEMALE_ADOLESCENT = "un'adolescente femmina";
-    private static final String MALE_ADOLESCENT = "un adolescente maschio";
-    private static final String ADOLESCENT = "un adolescente";
-
-    private static final String FEMALE_ADULT = "una donna";
-    private static final String MALE_ADULT = "un uomo";
-    private static final String ADULT = "una persona adulta";
-
-
-    /**
-     * Equivalent of "The clinical
-     * @param individual
-     * @return
-     */
-    public String ageAndSexAtOnset(PpktIndividual individual) {
-        Optional<PhenopacketAge> ageOpt = individual.getAgeAtOnset();
-        return "";
-    }
-
-
-
-
-    public String ageAndSexAtLastExamination(PpktIndividual individual) {
+    @Override
+    public String getIndividualDescription(PpktIndividual individual) {
+        if (individual.annotationCount() == 0) {
+            throw new PhenolRuntimeException("No HPO annotations");
+        }
+        Optional<PhenopacketAge> lastExamOpt = individual.getAgeAtLastExamination();
+        Optional<PhenopacketAge> onsetOpt = individual.getAgeAtOnset();
         PhenopacketSex psex = individual.getSex();
-        Optional<PhenopacketAge> ageOpt = individual.getAgeAtLastExamination();
-        if (ageOpt.isEmpty()) {
-            ageOpt = individual.getAgeAtOnset();
+        String individualDescription;
+        String onsetDescription;
+        if (lastExamOpt.isPresent()) {
+            var lastExamAge =  lastExamOpt.get();
+            if (lastExamAge.ageType().equals(PhenopacketAgeType.ISO8601_AGE_TYPE)) {
+                Iso8601Age isoAge = (Iso8601Age) lastExamAge;
+                individualDescription = iso8601individualDescription(psex, isoAge);
+            } else if (lastExamAge.ageType().equals(PhenopacketAgeType.HPO_ONSET_AGE_TYPE)) {
+                HpoOnsetAge hpoOnsetTermAge = (HpoOnsetAge) lastExamAge;
+                individualDescription = hpoOnsetIndividualDescription(psex, hpoOnsetTermAge);
+            } else {
+                // should never happen
+                throw new PhenolRuntimeException("Did not recognize last exam age type " + lastExamAge.ageType());
+            }
+        }  else {
+            individualDescription =  switch (psex) {
+                case FEMALE -> individualDescription = "La paziente era di sesso femminile e di età non specificata";
+                case MALE -> individualDescription = "Il paziente era di sesso maschile e di età non specificata";
+                default -> individualDescription = "Il paziente era di sesso e di età non specificati";
+            };
         }
-        String sex;
-        switch (psex) {
-            case FEMALE -> sex = "una paziente femmina";
-            case MALE -> sex = "un paziente maschio";
-            default -> sex = "una persona";
-        };
-
-        if (ageOpt.isEmpty()) {
-           return sex;
-        }
-        PhenopacketAge age = ageOpt.get();
-        if (age.ageType().equals(PhenopacketAgeType.ISO8601_AGE_TYPE)) {
-            Iso8601Age isoage = (Iso8601Age) age;
-            int y = isoage.getYears();
-            int m = isoage.getMonths();
-            int d = isoage.getDays();
-            if (psex.equals(PhenopacketSex.FEMALE)) {
-                if (y > 17) {
-                    return String.format("una donna di %d anni", y);
-                } else if (y > 9) {
-                    return String.format("un'adolescente femmina di %d anni", y);
-
-                } else if (y > 0) {
-                    return String.format("una bambina di %d anni", y);
-                } else if (m > 0) {
-                    return String.format("un'infante femmina di %d mesi", m);
-                } else  {
-                    return String.format("una neonata di %d giorni", d);
-                }
+        if (onsetOpt.isPresent()) {
+            var onsetAge = onsetOpt.get();
+            if (onsetAge.ageType().equals(PhenopacketAgeType.ISO8601_AGE_TYPE)) {
+                Iso8601Age isoAge = (Iso8601Age) onsetAge;
+                onsetDescription =  iso8601onsetDescription(isoAge);
+            } else if (onsetAge.ageType().equals(PhenopacketAgeType.HPO_ONSET_AGE_TYPE)) {
+                HpoOnsetAge hpoOnsetTermAge = (HpoOnsetAge) onsetAge;
+                onsetDescription = hpoOnsetDescription(hpoOnsetTermAge, psex);
+            } else {
+                // should never happen
+                throw new PhenolRuntimeException("Did not recognize last exam age type " + onsetAge.ageType());
             }
         } else {
-            // age is an HPO onset term, we do not have an exact date
+            onsetDescription = "Non venne indicata l'età dell'inizio della malattia";
         }
-        if (age.isChild()) {
-            return switch (psex) {
-                case FEMALE -> FEMALE_CHILD;
-                case MALE -> MALE_CHILD;
-                default -> CHILD; // difficult to be gender neutral
-            };
-        } else if (age.isCongenital()) {
-            return switch (psex) {
-                case FEMALE -> FEMALE_NEWBORN;
-                case MALE -> MALE_NEWBORN;
-                default -> NEWBORN;
-            };
-        } else if (age.isFetus()) {
-            return switch (psex) {
-                case FEMALE -> FEMALE_FETUS;
-                case MALE -> MALE_FETUS;
-                default -> FETUS;
-            };
-        } else if (age.isInfant()) {
-            return switch (psex) {
-                case FEMALE -> FEMALE_INFANT;
-                case MALE ->  MALE_INFANT;
-                default -> INFANT;
-            };
+        return String.format("%s. %s.", individualDescription, onsetDescription);
+
+    }
+
+    private String hpoOnsetDescription(HpoOnsetAge hpoOnsetTermAge, PhenopacketSex psex) {
+        return String.format("L'inizio della malattia avvenne %s",
+                nameOfLifeStage(hpoOnsetTermAge, psex));
+    }
+
+    private String nameOfLifeStage(HpoOnsetAge hpoOnsetTermAge, PhenopacketSex psex) {
+        if (hpoOnsetTermAge.isFetus()) {
+            return "durante il periodo fetale";
+        } else if (hpoOnsetTermAge.isCongenital()) {
+            return "alla nascita";
+        } else if (hpoOnsetTermAge.isInfant()) {
+            return "durante l'infanzia";
+        } else if (hpoOnsetTermAge.isChild()) {
+            return "da bambino";
+        } else if (hpoOnsetTermAge.isJuvenile()) {
+            return "nell'adolescenza";
+        } else if (hpoOnsetTermAge.isNeonate()) {
+            if (psex.equals(PhenopacketSex.FEMALE)) {
+                return "da neonata";
+            } else {
+                return "da nenoato";
+            }
+        } else if (hpoOnsetTermAge.isYoungAdult()) {
+            return "da giovane adulto" ;
+        } else if (hpoOnsetTermAge.isMiddleAge()) {
+            return "in media età" ;
+        } else if (hpoOnsetTermAge.isLateAdultAge()) {
+            return "da adulto di età avanzata" ;
+        } else if (hpoOnsetTermAge.isAdult()) {
+            // d.h. nicht weiter spezifiziert
+            return "nell'età adulta" ;
         } else {
-            return switch (psex) {
-                case FEMALE -> FEMALE_ADULT;
-                case MALE -> MALE_ADULT;
-                default -> ADULT;
-            };
+            throw new PhenolRuntimeException("Could not identify Italian life stage name for HpoOnsetAge " + hpoOnsetTermAge.toString());
         }
     }
 
+
+    private String ymd(Iso8601Age iso8601Age) {
+        int y = iso8601Age.getYears();
+        int m = iso8601Age.getMonths();
+        int d = iso8601Age.getDays();
+
+        List<String> components = new ArrayList<>();
+        if (y > 0) {
+            components.add(String.format("%d %s", y, y > 1 ? "anni" : "anno"));
+        }
+        if (m > 0) {
+            components.add(String.format("%d %s", m, m > 1 ? "mesi" : "mese"));
+        }
+        if (d > 0) {
+            components.add(String.format("%d %s", d, d > 1 ? "giorni" : "giorno"));
+        }
+        if (components.isEmpty()) {
+            return "nel primo giorno di vita";
+        } else if (components.size() == 1) {
+            return components.get(0);
+        } else if (components.size() == 2) {
+            return String.format("all'età di %s y %s", components.get(0), components.get(1));
+        } else {
+            // we must have y,m,d
+            return String.format("all'età di %s, %s y %s", components.get(0), components.get(1), components.get(2));
+        }
+    }
+
+    private String iso8601onsetDescription(Iso8601Age isoAge) {
+        return String.format("L'inizio della malattia avvenne all'età di %s", ymd(isoAge));
+    }
 
     private String atIsoAgeExact(PhenopacketAge ppktAge) {
         Iso8601Age iso8601Age = (Iso8601Age) ppktAge;
@@ -143,85 +149,10 @@ public class PpktIndividualItalian implements PPKtIndividualInfoGenerator {
         } else {
             return String.format("%d giorni",  d);
         }
-     }
-
-
-    @Override
-    public String getIndividualDescription(PpktIndividual individual) {
-        if (individual.annotationCount() == 0) {
-            throw new PhenolRuntimeException("No HPO annotations");
-        }
-        Optional<PhenopacketAge> lastExamOpt = individual.getAgeAtLastExamination();
-        Optional<PhenopacketAge> onsetOpt = individual.getAgeAtOnset();
-        PhenopacketSex psex = individual.getSex();
-        if (lastExamOpt.isPresent() && onsetOpt.isPresent()) {
-            return onsetAndLastEncounterAvailable(psex, lastExamOpt.get(), onsetOpt.get());
-        } else if (lastExamOpt.isPresent()) {
-            return lastEncounterAvailable(psex, lastExamOpt.get());
-        } else if (onsetOpt.isPresent()) {
-            return onsetAvailable(psex, onsetOpt.get());
-        } else {
-            return ageNotAvailable(psex);
-        }
     }
 
 
-    private String iso8601ToYearMonth(Iso8601Age iso8601Age) {
-        if (iso8601Age.getMonths() == 0) {
-            return String.format("di %d anni", iso8601Age.getYears());
-        } else {
-            return String.format("di %d anni e %d mesi", iso8601Age.getYears(), iso8601Age.getMonths());
-        }
-    }
-
-    private String iso8601ToMonthDay(Iso8601Age iso8601Age) {
-        int m = iso8601Age.getMonths();
-        int d = iso8601Age.getDays();
-        if (m == 0) {
-            return String.format("di %d giorni", d);
-        } else if (d>0){
-            return String.format("di %d mesi e %d giorni", m, d);
-        } else {
-            return String.format("di %d mesi", m);
-        }
-    }
-
-    /**
-     * Create a phrase such as "at the age of 7 years, 4 months, and 2 days"
-     * Leave out the months and days if they are zero.
-     * @param isoAge
-     * @return
-     */
-    private String iso8601AtAgeOf(Iso8601Age isoAge) {
-        List<String> components = new ArrayList<>();
-
-        if (isoAge.getYears()>1) {
-            components.add(String.format("%d anni", isoAge.getYears()));
-        } else if (isoAge.getYears() == 1) {
-            components.add("1 anno");
-        }
-        if (isoAge.getMonths() > 1) {
-            components.add(String.format("%d mesi", isoAge.getMonths()));
-        } else if (isoAge.getMonths() == 1) {
-            components.add("1 mese");
-        }
-        if (isoAge.getDays()>1) {
-            components.add(String.format("%d giorni", isoAge.getDays()));
-        } else if (isoAge.getDays()==1) {
-            components.add("1 giorno");
-        }
-        if (components.isEmpty()) {
-            return "nel periodo neonatale";
-        } else if (components.size() == 1) {
-            return "all'età di " + components.getFirst();
-        } else if (components.size() == 2) {
-            return "all'età di " + components.get(0) + " e " + components.get(1);
-        } else {
-            return "all'età di "  + components.get(0) + ", " + components.get(1) +
-                    " e " + components.get(2);
-        }
-    }
-
+    //TODO delete this method when sure no translation in it is needed
     private String onsetTermAtAgeOf(HpoOnsetAge hpoOnsetTermAge) {
         if (hpoOnsetTermAge.isFetus()) {
             return  "nel periodo fetale";
@@ -246,33 +177,33 @@ public class PpktIndividualItalian implements PPKtIndividualInfoGenerator {
         // if older
         if (y>17) {
             return switch (psex) {
-                case FEMALE -> String.format("una donna di %d anni", y);
-                case MALE -> String.format("un uomo di %d anni", y);
-                default -> String.format("una persona di %d anni", y);
+                case FEMALE -> String.format("La paziente era una donna di %d anni", y);
+                case MALE -> String.format("Il paziente era un uomo di %d anni", y);
+                default -> String.format("Il paziente era una persona di %d anni", y);
             };
         } else if (y>9) {
             return switch (psex) {
-                case FEMALE -> String.format("un'adolescente femmina di %d anni", y);
-                case MALE -> String.format("un adolescente maschio di %d anni", y);
-                default -> String.format("un adolescente di %d anni", y);
+                case FEMALE -> String.format("La paziente era un'adolescente femmina di %d anni", y);
+                case MALE -> String.format("Il paziente era un adolescente maschio di %d anni", y);
+                default -> String.format("Il paziente era un adolescente di %d anni", y);
             };
         } else if (y>0) {
             return switch (psex) {
-                case FEMALE -> String.format("bambina %s", iso8601ToYearMonth(iso8601Age));
-                case MALE -> String.format("bambino %s", iso8601ToYearMonth(iso8601Age));
-                default -> String.format("bambino %s", iso8601ToYearMonth(iso8601Age));
+                case FEMALE -> String.format("La paziente era una bambina %s", ymd(iso8601Age));
+                case MALE -> String.format("Il paziente era un bambino %s", ymd(iso8601Age));
+                default -> String.format("Il paziente era un bambino %s", ymd(iso8601Age));
             };
         } else if (m>0 || d> 0) {
             return switch (psex) {
-                case FEMALE -> String.format("%s %s", FEMALE_INFANT, iso8601ToMonthDay(iso8601Age));
-                case MALE -> String.format("%s %s", MALE_INFANT, iso8601ToMonthDay(iso8601Age));
-                default -> String.format("%s %s", INFANT, iso8601ToMonthDay(iso8601Age));
+                case FEMALE -> String.format("La paziente era un'infante %s", ymd(iso8601Age));
+                case MALE -> String.format("Il paziente era un infante %s", ymd(iso8601Age));
+                default -> String.format("Il paziente era un infante %s", ymd(iso8601Age));
             };
         } else {
             return switch (psex) {
-                case FEMALE -> FEMALE_NEWBORN;
-                case MALE -> MALE_NEWBORN;
-                default -> NEWBORN;
+                case FEMALE -> "La paziente era una neonata";
+                case MALE -> "Il paziente era un neonato";
+                default -> "Il paziente era un neonato";
             };
         }
     }
@@ -280,129 +211,63 @@ public class PpktIndividualItalian implements PPKtIndividualInfoGenerator {
     private String hpoOnsetIndividualDescription(PhenopacketSex psex, HpoOnsetAge hpoOnsetTermAge) {
         if (hpoOnsetTermAge.isFetus()) {
             return switch (psex) {
-                case FEMALE -> FEMALE_FETUS;
-                case MALE -> MALE_FETUS;
-                default -> FETUS;
+                case FEMALE -> "La paziente era un feto femmina";
+                case MALE -> "Il paziente era un feto maschio";
+                default -> "Il paziente era un feto";
             };
         } else if (hpoOnsetTermAge.isCongenital()) {
             return switch (psex) {
-                case FEMALE -> FEMALE_NEWBORN;
-                case MALE -> MALE_NEWBORN;
-                default -> NEWBORN;
+                case FEMALE ->  "La paziente era una neonata";
+                case MALE -> "Il paziente era un neonato";
+                default -> "Il paziente era un neonato";
             };
         } else if (hpoOnsetTermAge.isInfant()) {
             return switch (psex) {
-                case FEMALE -> FEMALE_INFANT;
-                case MALE -> MALE_INFANT;
-                default -> INFANT;
+                case FEMALE ->  "La paziente era un'infante'";
+                case MALE -> "Il paziente era un infante";
+                default -> "Il paziente era un infante";
             };
         } else if (hpoOnsetTermAge.isChild()) {
             return switch (psex) {
-                case FEMALE -> FEMALE_CHILD;
-                case MALE -> MALE_CHILD;
-                default -> CHILD;
+                case FEMALE -> "La paziente era una bambina";
+                case MALE -> "Il paziente era un bambino";
+                default -> "Il paziente era un bambino";
             };
         } else if (hpoOnsetTermAge.isJuvenile()) {
             return switch (psex) {
-                case FEMALE -> FEMALE_ADOLESCENT;
-                case MALE -> MALE_ADOLESCENT;
-                default -> ADOLESCENT;
+                case FEMALE -> "La paziente era un'adolescente femmina";
+                case MALE -> "Il paziente era un adolescente maschio";
+                default -> "Il paziente era un adolescente";
             };
-        }else {
+        } else if (hpoOnsetTermAge.isMiddleAge()) {
             return switch (psex) {
-                case FEMALE -> FEMALE_ADULT;
-                case MALE -> MALE_ADULT;
-                default -> ADULT;
+                case FEMALE -> "La paziente era una donna di media età";
+                case MALE -> "Il paziente era un uomo di media età";
+                default -> "Il paziente era un adulto di media età";
             };
-        }
-    }
-
-    /**
-     * A sentence such as The proband was a 39-year old woman who presented at the age of 12 years with
-     * HPO1, HPO2, and HPO3. HPO4 and HPO5 were excluded. This method returns the phrase that ends with "with"
-     * El sujeto era un niño de 1 año y 10 meses que se presentó como recién nacido con un filtrum largo.
-     * @param psex
-     * @param lastExamAge
-     * @param onsetAge
-     * @return
-     */
-    private String onsetAndLastEncounterAvailable(PhenopacketSex psex, PhenopacketAge lastExamAge, PhenopacketAge onsetAge) {
-        String individualDescription;
-        String onsetDescription;
-        if (lastExamAge.ageType().equals(PhenopacketAgeType.ISO8601_AGE_TYPE)) {
-            Iso8601Age isoAge = (Iso8601Age) lastExamAge;
-            individualDescription = iso8601individualDescription(psex, isoAge);
-        } else if (lastExamAge.ageType().equals(PhenopacketAgeType.HPO_ONSET_AGE_TYPE)) {
-            HpoOnsetAge hpoOnsetTermAge = (HpoOnsetAge) lastExamAge;
-            individualDescription = hpoOnsetIndividualDescription(psex,hpoOnsetTermAge);
+        }  else if (hpoOnsetTermAge.isYoungAdult()) {
+            return switch (psex) {
+                case FEMALE -> "La paziente era una giovane donna adulta";
+                case MALE -> "Il paziente era un giovane uomo adulto";
+                default -> "Il paziente era una giovane persona adulta";
+            };
+        } else if (hpoOnsetTermAge.isLateAdultAge()) {
+            return switch (psex) {
+                case FEMALE -> "La paziente era una donna di età avanzata";
+                case MALE -> "Il paziente era un uomo di età avanzata";
+                default -> "Il paziente era un adulto di età avanzata";
+            };
+        } else if (hpoOnsetTermAge.isAdult()) {
+            return switch (psex) {
+                case FEMALE -> "La paziente era una donna";
+                case MALE -> "Il paziente era un uomo";
+                default -> "Il paziente era un adulto";
+            };
         } else {
-            // should never happen
-            throw new PhenolRuntimeException("Did not recognize last exam age type " + lastExamAge.ageType());
+            throw new PhenolRuntimeException("Did not recognize Italian HPO Onset term");
         }
-        if (onsetAge.ageType().equals(PhenopacketAgeType.ISO8601_AGE_TYPE)) {
-            Iso8601Age isoAge = (Iso8601Age) onsetAge;
-            onsetDescription = iso8601AtAgeOf(isoAge);
-        } else if (onsetAge.ageType().equals(PhenopacketAgeType.HPO_ONSET_AGE_TYPE)) {
-            HpoOnsetAge hpoOnsetTermAge = (HpoOnsetAge) onsetAge;
-            onsetDescription = onsetTermAtAgeOf(hpoOnsetTermAge);
-        } else {
-            // should never happen
-            throw new PhenolRuntimeException("Did not recognize onset age type " + onsetAge.ageType());
-        }
-        return String.format("Il soggetto era %s che si è presentato %s con", individualDescription, onsetDescription);
     }
 
-
-    /**
-     * Age at last examination available but age of onset not available
-     * The proband was a 39-year old woman who presented with HPO1, HPO2, and HPO3. HPO4 and HPO5 were excluded.
-     * @param psex
-     * @param lastExamAge
-     */
-    private String lastEncounterAvailable(PhenopacketSex psex, PhenopacketAge lastExamAge) {
-        String individualDescription;
-        if (lastExamAge.ageType().equals(PhenopacketAgeType.ISO8601_AGE_TYPE)) {
-            Iso8601Age isoAge = (Iso8601Age) lastExamAge;
-            individualDescription = iso8601individualDescription(psex, isoAge);
-        } else if (lastExamAge.ageType().equals(PhenopacketAgeType.HPO_ONSET_AGE_TYPE)) {
-            HpoOnsetAge hpoOnsetTermAge = (HpoOnsetAge) lastExamAge;
-            individualDescription = hpoOnsetIndividualDescription(psex,hpoOnsetTermAge);
-        } else {
-            // should never happen
-            throw new PhenolRuntimeException("Did not recognize last exam age type " + lastExamAge.ageType());
-        }
-        return String.format("Il soggetto era %s che si è presentato ", individualDescription);
-    }
-
-    /**
-     * Age at last examination not available but age of onset available
-     * The proband  presented  at the age of 12 years with HPO1, HPO2, and HPO3. HPO4 and HPO5 were excluded.
-     * @param psex
-     * @param onsetAge
-     * @return
-     */
-    private String onsetAvailable(PhenopacketSex psex, PhenopacketAge onsetAge) {
-        String onsetDescription;
-        if (onsetAge.ageType().equals(PhenopacketAgeType.ISO8601_AGE_TYPE)) {
-            Iso8601Age isoAge = (Iso8601Age) onsetAge;
-            onsetDescription = iso8601AtAgeOf(isoAge);
-        } else if (onsetAge.ageType().equals(PhenopacketAgeType.HPO_ONSET_AGE_TYPE)) {
-            HpoOnsetAge hpoOnsetTermAge = (HpoOnsetAge) onsetAge;
-            onsetDescription = onsetTermAtAgeOf(hpoOnsetTermAge);
-        } else {
-            // should never happen
-            throw new PhenolRuntimeException("Did not recognize onset age type " + onsetAge.ageType());
-        }
-        return String.format("Il soggetto si è presentato %s con", onsetDescription);
-    }
-
-    private String ageNotAvailable(PhenopacketSex psex) {
-        return switch (psex) {
-            case FEMALE -> "Il soggetto era una femmina che si è presentata con";
-            case MALE -> "Il soggetto era un maschio si è presentato con";
-            default -> "Il soggetto si è presentato con";
-        };
-    }
 
     @Override
     public String heSheIndividual(PhenopacketSex psex) {
@@ -429,54 +294,6 @@ public class PpktIndividualItalian implements PPKtIndividualInfoGenerator {
             };
         } else {
             return ""; // should never get here
-        }
-    }
-
-  //  @Override
-    public String ppktSex(PpktIndividual individual) {
-        PhenopacketSex psex = individual.getSex();
-        Optional<PhenopacketAge> ageOpt = individual.getAgeAtLastExamination();
-        if (ageOpt.isEmpty()) {
-            ageOpt = individual.getAgeAtOnset();
-        }
-        if (ageOpt.isEmpty()) {
-            return switch (psex) {
-                case FEMALE -> FEMALE_ADULT;
-                case MALE -> MALE_ADULT;
-                default -> ADULT;
-            };
-        }
-        PhenopacketAge age = ageOpt.get();;
-        if (age.isChild()) {
-            return switch (psex) {
-                case FEMALE -> FEMALE_CHILD;
-                case MALE -> MALE_CHILD;
-                default -> CHILD;
-            };
-        } else if (age.isCongenital()) {
-            return switch (psex) {
-                case FEMALE -> FEMALE_NEWBORN;
-                case MALE -> MALE_NEWBORN;
-                default -> NEWBORN;
-            };
-        } else if (age.isFetus()) {
-            return switch (psex) {
-                case FEMALE -> FEMALE_FETUS;
-                case MALE -> MALE_FETUS;
-                default -> FETUS;
-            };
-        } else if (age.isInfant()) {
-            return switch (psex) {
-                case FEMALE -> FEMALE_INFANT;
-                case MALE -> MALE_INFANT;
-                default -> INFANT;
-            };
-        } else {
-            return switch (psex) {
-                case FEMALE -> FEMALE_ADULT;
-                case MALE -> MALE_ADULT;
-                default -> ADULT;
-            };
         }
     }
 

--- a/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/italian/PpktIndividualItalian.java
+++ b/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/italian/PpktIndividualItalian.java
@@ -71,7 +71,7 @@ public class PpktIndividualItalian implements PPKtIndividualInfoGenerator {
         } else if (hpoOnsetTermAge.isCongenital()) {
             return "alla nascita";
         } else if (hpoOnsetTermAge.isInfant()) {
-            return "durante l'infanzia";
+            return "durante il periodo infantile";
         } else if (hpoOnsetTermAge.isChild()) {
             return "da bambino";
         } else if (hpoOnsetTermAge.isJuvenile()) {
@@ -195,9 +195,9 @@ public class PpktIndividualItalian implements PPKtIndividualInfoGenerator {
             };
         } else if (m>0 || d> 0) {
             return switch (psex) {
-                case FEMALE -> String.format("La paziente era un'infante %s", ymd(iso8601Age));
-                case MALE -> String.format("Il paziente era un infante %s", ymd(iso8601Age));
-                default -> String.format("Il paziente era un infante %s", ymd(iso8601Age));
+                case FEMALE -> String.format("La paziente era un'infante femmina di %s", ymd(iso8601Age));
+                case MALE -> String.format("Il paziente era un infante maschio di %s", ymd(iso8601Age));
+                default -> String.format("Il paziente era un infante di %s", ymd(iso8601Age));
             };
         } else {
             return switch (psex) {

--- a/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/italian/PpktPhenotypicfeatureItalian.java
+++ b/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/italian/PpktPhenotypicfeatureItalian.java
@@ -1,26 +1,24 @@
 package org.monarchinitiative.phenopacket2prompt.output.impl.italian;
 
+import org.monarchinitiative.phenol.base.PhenolRuntimeException;
 import org.monarchinitiative.phenopacket2prompt.international.HpInternational;
 import org.monarchinitiative.phenopacket2prompt.model.OntologyTerm;
 import org.monarchinitiative.phenopacket2prompt.output.PpktPhenotypicFeatureGenerator;
 
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class PpktPhenotypicfeatureItalian implements PpktPhenotypicFeatureGenerator {
 
     private final HpInternational italian;
-
-    private Set<String> missingTranslations;
-
-
 
     public PpktPhenotypicfeatureItalian(HpInternational international) {
         italian = international;
         missingTranslations = new HashSet<>();
     }
 
-
+    private Set<String> missingTranslations;
 
     private List<String> getTranslations(List<OntologyTerm> ontologyTerms) {
         List<String> labels = new ArrayList<>();
@@ -39,26 +37,36 @@ public class PpktPhenotypicfeatureItalian implements PpktPhenotypicFeatureGenera
 
     private final Set<Character> vowels = Set.of('A', 'E', 'I', 'O', 'U');
 
-    private String getOxfordCommaList(List<String> items) {
+    String getConnector(String nextWord) {
+        if (nextWord.length() < 2) {
+            return " e "; // should never happen but do not want to crash
+        }
+        char letter = nextWord.charAt(0);
+        if (vowels.contains(letter)) {
+            return " ed ";
+        }
+
+        return " e ";
+
+    }
+
+    private String getCommaList(List<String> items) {
+        if (items.isEmpty()) return ""; // will be filtered out
         if (items.size() == 1) {
             return items.getFirst();
         }
         if (items.size() == 2) {
             // no comma if we just have two items.
             // one item will work with the below code
-            return String.join(" e ", items);
+            String connector = getConnector(items.get(1));
+            return String.join(connector, items);
         }
-        String symList = String.join(", ", items);
-        int jj = symList.lastIndexOf(", ");
-        if (jj > 0) {
-            String end = symList.substring(jj+2);
-            if (vowels.contains(end.charAt(0))) {
-                symList = symList.substring(0, jj) + " e " + end;
-            } else {
-                symList = symList.substring(0, jj) + " e " + end;
-            }
-        }
-        return symList;
+        // if we have more than two, join all but the very last item with a comma
+        String penultimate = items.stream()
+                .limit(items.size() - 1)
+                .collect(Collectors.joining(","));
+        String ultimate = items.get(items.size() - 1);
+        return penultimate + getConnector(ultimate) + ultimate;
     }
 
     @Override
@@ -71,26 +79,75 @@ public class PpktPhenotypicfeatureItalian implements PpktPhenotypicFeatureGenera
                 .filter(OntologyTerm::isExcluded).toList();
         List<String> excludedLabels = getTranslations(excludedTerms);
         if (observedLabels.isEmpty() && excludedLabels.isEmpty()) {
-            return "nessuna anomalia fenotipica"; // should never happen, actually!
+            return "Nessuna anomalia fenotipica"; // should never happen, actually!
         } else if (excludedLabels.isEmpty()) {
-            return getOxfordCommaList(observedLabels) + ". ";
+            return getCommaList(observedLabels) + ". ";
         } else if (observedLabels.isEmpty()) {
             if (excludedLabels.size() > 1) {
-                return String.format("E' stata esclusa la presenza dei seguenti sintomi: %s.", getOxfordCommaList(excludedLabels));
+                return String.format("si escluse la presenza di %s.", getCommaList(excludedLabels));
             } else {
-                return String.format("E' stata esclusa la presenza del seguente sintomo: %s.",excludedLabels.getFirst());
+                return String.format("si escluse la presenza di %s.",excludedLabels.getFirst());
             }
         } else {
             String exclusion;
             if (excludedLabels.size() == 1) {
-                exclusion = String.format(" ed è stata esclusa la presenza di %s.", getOxfordCommaList(excludedLabels));
+                exclusion = String.format(". Al contrario, si escluse la presenza di %s.", getCommaList(excludedLabels));
             } else {
-                exclusion =  String.format(" ed è stata esclusa la presenza di %s.", getOxfordCommaList(excludedLabels));
+                exclusion =  String.format(". Al contrario, si escluse la presenza di %s.", getCommaList(excludedLabels));
             }
-            return getOxfordCommaList(observedLabels) +  exclusion;
+            return getCommaList(observedLabels) +  exclusion;
         }
     }
     public Set<String> getMissingTranslations() {
         return missingTranslations;
+    }
+
+    @Override
+    public String featuresAtOnset(String personString, List<OntologyTerm> ontologyTerms) {
+        List<OntologyTerm> observed = getObservedFeatures(ontologyTerms);
+        List<OntologyTerm> excluded = getExcludedFeatures(ontologyTerms);
+        List<String> observedSpanish = getTranslations(observed);
+        List<String> excludedSpanish = getTranslations(excluded);
+        var observedStr = getCommaList(observedSpanish);
+        var excludedStr = getCommaList(excludedSpanish);
+        if (!observed.isEmpty() && ! excluded.isEmpty()) {
+            return String.format("%s presentò i sequenti sintomi: %s. Al contrario, si %s: %s.",
+                    personString,
+                    observedStr,
+                    excluded.size()>1? "esclusero i sequenti sintomi":"escluse il sequente sintomo",
+                    excludedStr);
+        } else if (!observed.isEmpty()) {
+            return String.format("%s presentò i sequenti sintomi: %s.", personString, observedStr);
+        } else if (!excluded.isEmpty()) {
+            return String.format("All'inizio della malattia, si %s: %s.",
+                    excluded.size()>1? "esclusero i seguenti sintomi":"escluse il seguente sintomo", excludedStr);
+        } else {
+            return "Non vennero descritte esplicitamente anomalie fenotipiche al principio de della malattia";
+        }
+    }
+    @Override
+    public String featuresAtEncounter(String personString, String ageString, List<OntologyTerm> ontologyTerms) {
+        List<OntologyTerm> observed = getObservedFeatures(ontologyTerms);
+        List<OntologyTerm> excluded = getExcludedFeatures(ontologyTerms);
+        List<String> observedGerman = getTranslations(observed);
+        List<String> excludedGerman = getTranslations(excluded);
+        var observedStr = getCommaList(observedGerman);
+        var excludedStr = getCommaList(excludedGerman);
+        if (!observed.isEmpty() && ! excluded.isEmpty()) {
+            return String.format("%s presentava %s i seguenti sintomi: %s. Al contrario, si %s i seguenti sintomi: %s.",
+                    personString,
+                    ageString,
+                    observedStr,
+                    excluded.size()>1? "esclusero":"escluse",
+                    excludedStr);
+        } else if (!observed.isEmpty()) {
+            return String.format("%s presentava %s i seguenti sintomi: %s.", ageString, personString,  observedStr);
+        } else if (!excluded.isEmpty()) {
+            return String.format("%s si %s i seguenti sintomi: %s.",
+                    ageString,
+                    excluded.size()>1? "esclusero":"escluse", excludedStr);
+        } else {
+            throw new PhenolRuntimeException("No features found for time point " + ageString); // should never happen
+        }
     }
 }

--- a/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/spanish/PpktIndividualSpanish.java
+++ b/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/spanish/PpktIndividualSpanish.java
@@ -128,7 +128,7 @@ public class PpktIndividualSpanish implements PPKtIndividualInfoGenerator {
             return String.format("en la edad de %s y %s", components.get(0), components.get(1));
         } else {
             // we must have y,m,d
-            return String.format("en la edad de  %s, %s y %s", components.get(0), components.get(1), components.get(2));
+            return String.format("en la edad de %s, %s y %s", components.get(0), components.get(1), components.get(2));
         }
     }
 
@@ -185,7 +185,7 @@ public class PpktIndividualSpanish implements PPKtIndividualInfoGenerator {
             };
         } else if (y>0) {
             return switch (psex) {
-                case FEMALE -> String.format("La paciente una niña %s", ymd(iso8601Age));
+                case FEMALE -> String.format("La paciente era una niña %s", ymd(iso8601Age));
                 case MALE -> String.format("El paciente era un niño %s", ymd(iso8601Age));
                 default -> String.format("El paciente era un niño %s", ymd(iso8601Age));
             };

--- a/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/spanish/PpktIndividualSpanish.java
+++ b/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/spanish/PpktIndividualSpanish.java
@@ -44,8 +44,8 @@ public class PpktIndividualSpanish implements PPKtIndividualInfoGenerator {
             }
         }  else {
             individualDescription =  switch (psex) {
-                case FEMALE -> individualDescription = "La paciente era de sexo femenino de edad no especificada";
-                case MALE -> individualDescription = "El paciente era de sexo masculino de edad no especificada";
+                case FEMALE -> individualDescription = "La paciente era de sexo femenino y de edad no especificada";
+                case MALE -> individualDescription = "El paciente era de sexo masculino y de edad no especificada";
                 default -> individualDescription = "El paciente era una persona de sexo y edad no especificados";
             };
         }
@@ -185,16 +185,16 @@ public class PpktIndividualSpanish implements PPKtIndividualInfoGenerator {
             };
         } else if (y>0) {
             return switch (psex) {
-                case FEMALE -> String.format("La paciente era una niña %s", ymd(iso8601Age));
-                case MALE -> String.format("El paciente era un niño %s", ymd(iso8601Age));
-                default -> String.format("El paciente era un niño %s", ymd(iso8601Age));
+                case FEMALE -> String.format("La paciente era una niña de %s", ymd(iso8601Age));
+                case MALE -> String.format("El paciente era un niño de %s", ymd(iso8601Age));
+                default -> String.format("El paciente era un niño de %s", ymd(iso8601Age));
             };
         } else if (m>0 || d> 0) {
             return switch (psex) {
                 // note that in Spanish infante is up to 5 years
-                case FEMALE -> String.format("La paciente era una bebé %s", ymd(iso8601Age));
-                case MALE -> String.format("El paciente era un bebé %s", ymd(iso8601Age));
-                default -> String.format("El paciente era un bebé %s", ymd(iso8601Age));
+                case FEMALE -> String.format("La paciente era una bebé de %s", ymd(iso8601Age));
+                case MALE -> String.format("El paciente era un bebé de %s", ymd(iso8601Age));
+                default -> String.format("El paciente era un bebé de %s", ymd(iso8601Age));
             };
         } else {
             return switch (psex) {

--- a/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/spanish/PpktPhenotypicfeatureSpanish.java
+++ b/src/main/java/org/monarchinitiative/phenopacket2prompt/output/impl/spanish/PpktPhenotypicfeatureSpanish.java
@@ -127,8 +127,8 @@ public class PpktPhenotypicfeatureSpanish implements PpktPhenotypicFeatureGenera
         } else if (!observed.isEmpty()) {
             return String.format("%s presentó los siguientes síntomas: %s.", personString, observedStr);
         } else if (!excluded.isEmpty()) {
-            return String.format("Al inicio de la enfermedad, se %s los siguientes síntomas: %s.",
-                    excluded.size()>1? "excluyeron":"excluyeró", excludedStr);
+            return String.format("Al inicio de la enfermedad, se %s: %s.",
+                    excluded.size()>1? "excluyeron los siguientes síntomas":"excluyeró el siguiente síntoma", excludedStr);
         } else {
             return "No se describieron explícitamente anomalías fenotípicas al inicio de la enfermedad";
         }

--- a/src/test/java/org/monarchinitiative/phenopacket2prompt/output/impl/italian/PpktIndividualItalianTest.java
+++ b/src/test/java/org/monarchinitiative/phenopacket2prompt/output/impl/italian/PpktIndividualItalianTest.java
@@ -21,15 +21,15 @@ public class PpktIndividualItalianTest extends PPKtIndividualBase{
     private static Stream<TestIndividual> testGetIndividualDescription() {
         return Stream.of(
                 new TestIndividual("46 year old female, infantile onset",
-                        female46yearsInfantileOnset(), new TestOutcome.Ok("Il soggetto era una donna di 46 anni che si è presentato nel periodo infantile con")),
+                        female46yearsInfantileOnset(), new TestOutcome.Ok("La paziente era una donna di 46 anni. L'inizio della malattia avvenne durante il periodo infantile.")),
                 new TestIndividual("male 4 months, congenital onset",
-                        male4monthsCongenitalOnset(), new TestOutcome.Ok("Il soggetto era un infante maschio di 4 mesi che si è presentato alla nascita con")),
+                        male4monthsCongenitalOnset(), new TestOutcome.Ok("Il paziente era un infante maschio di 4 mesi. L'inizio della malattia avvenne alla nascita.")),
                 new TestIndividual("female, no onset",
-                        femaleNoAge(), new TestOutcome.Ok("Il soggetto era una femmina che si è presentata con")),
+                        femaleNoAge(), new TestOutcome.Ok("La paziente era di sesso femminile e di età non specificata. Non venne indicata l'età dell'inizio della malattia.")),
                 new TestIndividual("female, no HPOs",
                         femaleNoHPOs(), new TestOutcome.Error(() -> new PhenolRuntimeException("Nessuna anomalia fenotipica"))),
                 new TestIndividual("unknown sex, no 4yo",
-                        unknownSex4YearsOnset(),  new TestOutcome.Ok("Il soggetto si è presentato da bambino con"))
+                        unknownSex4YearsOnset(),  new TestOutcome.Ok("Il paziente era di sesso e di età non specificati. L'inizio della malattia avvenne da bambino."))
         );
     }
 

--- a/src/test/java/org/monarchinitiative/phenopacket2prompt/output/impl/spanish/PpktIndividualSpanishTest.java
+++ b/src/test/java/org/monarchinitiative/phenopacket2prompt/output/impl/spanish/PpktIndividualSpanishTest.java
@@ -21,15 +21,15 @@ public class PpktIndividualSpanishTest extends PPKtIndividualBase{
     private static Stream<TestIndividual> testGetIndividualDescription() {
         return Stream.of(
                 new TestIndividual("46 year olf female, infantile onset",
-                        female46yearsInfantileOnset(), new TestOutcome.Ok("La paciente era una mujer de 46 años que se presentó en el primer año de vida con")),
+                        female46yearsInfantileOnset(), new TestOutcome.Ok("La paciente era una mujer de 46 años. El inicio de la enfermedad ocurrió en la infancia temprana.")),
                 new TestIndividual("male 4 months, congenital onset",
-                       male4monthsCongenitalOnset(), new TestOutcome.Ok("El paciente era un bebé de 4 meses que se presentó al nacer con")),
+                       male4monthsCongenitalOnset(), new TestOutcome.Ok("El paciente era un bebé de 4 meses. El inicio de la enfermedad ocurrió en el momento del nacimiento.")),
                 new TestIndividual("female, no onset",
-                        femaleNoAge(), new TestOutcome.Ok("La paciente se presentó con")),
+                        femaleNoAge(), new TestOutcome.Ok("La paciente era de sexo femenino y de edad no especificada. No se indicó la edad del inicio de la enfermedad.")),
                 new TestIndividual("female, no HPOs",
                         femaleNoHPOs(), new TestOutcome.Error(() -> new PhenolRuntimeException("No HPO annotations"))),
                 new TestIndividual("unknown sex, no 4yo",
-                        unknownSex4YearsOnset(),  new TestOutcome.Ok("El paciente se presentó en la niñez con"))
+                        unknownSex4YearsOnset(),  new TestOutcome.Ok("El paciente era una persona de sexo y edad no especificados. El inicio de la enfermedad ocurrió en la niñez."))
         );
     }
 


### PR DESCRIPTION
Refactored Italian code according to new standard, where we split the patient-specific part of the prompt into multiple sentences instead of a single, quite long, sentence. This is done without the "building blocks", as discussed. Also some corrections in the Spanish, which I observed while using it as a base to translate to Italian.