### PR TITLE
Do not crash if translation missing

### DIFF
--- a/src/main/java/org/monarchinitiative/phenopacket2prompt/cmd/Utility.java
+++ b/src/main/java/org/monarchinitiative/phenopacket2prompt/cmd/Utility.java
@@ -161,8 +161,7 @@ public class Utility {
             } catch (Exception e) {
                 String errmsg = String.format("[ERROR] Could not process %s: %s\n", promptFileName, e.getMessage());
                 System.err.println(errmsg);
-                throw new PhenolRuntimeException(errmsg);
-                //e.printStackTrace();
+                LOGGER.error(errmsg);
             }
         }
 


### PR DESCRIPTION
I think this should fix:
https://github.com/monarch-initiative/phenopacket2prompt/issues/50
It writes the errors to the log command line. we will need to output a log file and check the log for the final analysis to make sure we are not missing errors we do not want to miss.